### PR TITLE
Add mzbench worker anti-affinity for k8s

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,16 +42,17 @@ ENV ORIG_PATH=$PATH
 ENV CODE_LOADING_MODE=interactive
 
 # Refer https://kubernetes.io/docs/setup/release/notes/
-ARG KUBECTL_VERSION=1.10.7
-ARG KUBECTL_CHECKSUM=169b57c6707ed8d8be9643b0088631e5c0c6a37a5e99205f03c1199cd32bc61e
+ARG KUBECTL_VERSION=1.14.0
+ARG KUBECTL_CHECKSUM=1b9ac17f26e2d05d1568a992cdef2b2024ba5bc2f17233ab4314ca47f424de27
 
 ENV MZBENCH_API_DIR /opt/mzbench_api
 ENV HOME_DIR /root
 
 COPY requirements.txt /tmp
 
-# Install packages, install kubectl (refer https://kubernetes.io/docs/setup/release/notes/), 
+# Install packages, install kubectl (refer https://kubernetes.io/docs/setup/release/notes/),
 #    create ssh keys, make server.config
+RUN apk add --update make
 RUN apk add --no-cache libstdc++ git curl openssh openssh-server bash rsync net-tools py2-pip \
     && curl -O -L https://dl.k8s.io/v${KUBECTL_VERSION}/kubernetes-client-linux-amd64.tar.gz \
     && echo "${KUBECTL_CHECKSUM}  kubernetes-client-linux-amd64.tar.gz" | sha256sum -c - \
@@ -65,10 +66,18 @@ RUN apk add --no-cache libstdc++ git curl openssh openssh-server bash rsync net-
     && cat /etc/ssh/ssh_host_rsa_key.pub >> ${HOME_DIR}/.ssh/authorized_keys \
     && chmod 0600 ${HOME_DIR}/.ssh/authorized_keys \
     && pip install -r /tmp/requirements.txt \
-    && echo "[{mzbench_api, [ {auto_update_deployed_code, disable}, {custom_os_code_builds, disable}, {network_interface, \"0.0.0.0\"},{listen_port, 80}]}]." > /etc/mzbench/server.config
+    && echo "[{mzbench_api, [ {auto_update_deployed_code, disable}, {custom_os_code_builds, disable}, {network_interface, \"0.0.0.0\"},{listen_port, 80}]}]." > /etc/mzbench/server.config \
+    && echo "Add public key to github ssh: https://help.github.com/en/articles/connecting-to-github-with-ssh" \
+    && echo "Public Key:" && cat /etc/ssh/ssh_host_rsa_key.pub \
+    && ssh-keyscan -t rsa github.com >> ${HOME_DIR}/.ssh/known_hosts
+
 
 COPY --from=build $MZBENCH_API_DIR $MZBENCH_API_DIR
 COPY --from=build ${HOME_DIR}/.local ${HOME_DIR}/.local
+
+# SSH requires root to have a password. Otherwise it will prompt for an interactive password
+RUN echo "root:Docker!" | chpasswd
+RUN echo "PasswordAuthentication no" > /etc/ssh/sshd_config
 
 EXPOSE 80
 WORKDIR $MZBENCH_API_DIR


### PR DESCRIPTION
Changes:
1. Add pod anti-affinity for mzbench-worker pods
2. Remove pod resource limit 
3. Upgrade kubectl version to : `KUBECTL_VERSION=1.14.0`. This is required in order to use `kubectl wait`