### PR TITLE
Fix low disk space alert message for docker installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ COPY requirements.txt /tmp
 
 # Install packages, install kubectl (refer https://kubernetes.io/docs/setup/release/notes/), 
 #    create ssh keys, make server.config
-RUN apk add --no-cache libstdc++ git curl openssh openssh-server bash rsync net-tools py2-pip \
+RUN apk add --no-cache libstdc++ git curl openssh openssh-server bash rsync net-tools py2-pip coreutils \
     && curl -O -L https://dl.k8s.io/v${KUBECTL_VERSION}/kubernetes-client-linux-amd64.tar.gz \
     && echo "${KUBECTL_CHECKSUM}  kubernetes-client-linux-amd64.tar.gz" | sha256sum -c - \
     && tar -xf kubernetes-client-linux-amd64.tar.gz \


### PR DESCRIPTION

<img width="559" alt="alert" src="https://user-images.githubusercontent.com/6338981/59846649-7aa91680-9371-11e9-8d11-83cd16c32208.png">


There is a message on the MZBench Docker installation: `Low disk space, currently 0 KB left.`, although it is not true.

After reading the source code of `MZBench` and erlang `os_mon` lib, I found that the problem in the default alpine BusyBox `df` application:

```
disk_status() ->
  FreeRequired = application:get_env(mzbench_api, warn_free_disk_kb, 0),
  case disksup:get_disk_data() of
      [{"none",0,0}] -> {1, 0};
      DiskUsage -> Free = lists:sum([(100 - Percent) * Size / 100||{_, Size, Percent} <- DiskUsage]),
          if Free < FreeRequired -> {0, Free};
              true -> {1, Free}
          end
  end.
```

https://github.com/erlang/otp/blob/master/lib/os_mon/src/disksup.erl

```
8> os:type().
{unix,linux}
```

```
check_disk_space({unix, linux}, Port, Threshold) ->
    Result = my_cmd("/bin/df -lk", Port),
    check_disks_solaris(skip_to_eol(Result), Threshold);
```

```
/opt/mzbench_api # /bin/df -lk
/bin/df: unrecognized option: l
BusyBox v1.29.3 (2019-01-24 07:45:07 UTC) multi-call binary.

Usage: df [-PkmhTai] [-B SIZE] [FILESYSTEM]...

Print filesystem usage statistics

	-P	POSIX output format
	-k	1024-byte blocks (default)
	-m	1M-byte blocks
	-h	Human readable (e.g. 1K 243M 2G)
	-T	Print filesystem type
	-a	Show all filesystems
	-i	Inodes
	-B SIZE	Blocksize
```

So we need to install gnu coreutils.