### PR TITLE
Add password to root user and set no password auth for ssh config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ RUN apk add --no-cache libstdc++ git curl openssh openssh-server bash rsync net-
     && cp /etc/ssh/ssh_host_rsa_key ${HOME_DIR}/.ssh/id_rsa \
     && cat /etc/ssh/ssh_host_rsa_key.pub >> ${HOME_DIR}/.ssh/authorized_keys \
     && chmod 0600 ${HOME_DIR}/.ssh/authorized_keys \
-    && echo "root:Docker!" | chpasswd && "PasswordAuthentication no" > /etc/ssh/sshd_config \
+    && echo "root:Docker!" | chpasswd && echo "PasswordAuthentication no" > /etc/ssh/sshd_config \
     && pip install -r /tmp/requirements.txt \
     && echo "[{mzbench_api, [ {auto_update_deployed_code, disable}, {custom_os_code_builds, disable}, {network_interface, \"0.0.0.0\"},{listen_port, 80}]}]." > /etc/mzbench/server.config
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ ENV HOME_DIR /root
 
 COPY requirements.txt /tmp
 
-# Install packages, install kubectl (refer https://kubernetes.io/docs/setup/release/notes/), 
+# Install packages, install kubectl (refer https://kubernetes.io/docs/setup/release/notes/),
 #    create ssh keys, make server.config
 RUN apk add --no-cache libstdc++ git curl openssh openssh-server bash rsync net-tools py2-pip \
     && curl -O -L https://dl.k8s.io/v${KUBECTL_VERSION}/kubernetes-client-linux-amd64.tar.gz \
@@ -69,6 +69,9 @@ RUN apk add --no-cache libstdc++ git curl openssh openssh-server bash rsync net-
 
 COPY --from=build $MZBENCH_API_DIR $MZBENCH_API_DIR
 COPY --from=build ${HOME_DIR}/.local ${HOME_DIR}/.local
+
+# SSH requires root to have a password. Otherwise it will prompt for an interactive password
+RUN echo "root:Docker!" | chpasswd && "PasswordAuthentication no" > /etc/ssh/sshd_config
 
 EXPOSE 80
 WORKDIR $MZBENCH_API_DIR

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,14 +64,12 @@ RUN apk add --no-cache libstdc++ git curl openssh openssh-server bash rsync net-
     && cp /etc/ssh/ssh_host_rsa_key ${HOME_DIR}/.ssh/id_rsa \
     && cat /etc/ssh/ssh_host_rsa_key.pub >> ${HOME_DIR}/.ssh/authorized_keys \
     && chmod 0600 ${HOME_DIR}/.ssh/authorized_keys \
+    && echo "root:Docker!" | chpasswd && "PasswordAuthentication no" > /etc/ssh/sshd_config \
     && pip install -r /tmp/requirements.txt \
     && echo "[{mzbench_api, [ {auto_update_deployed_code, disable}, {custom_os_code_builds, disable}, {network_interface, \"0.0.0.0\"},{listen_port, 80}]}]." > /etc/mzbench/server.config
 
 COPY --from=build $MZBENCH_API_DIR $MZBENCH_API_DIR
 COPY --from=build ${HOME_DIR}/.local ${HOME_DIR}/.local
-
-# SSH requires root to have a password. Otherwise it will prompt for an interactive password
-RUN echo "root:Docker!" | chpasswd && "PasswordAuthentication no" > /etc/ssh/sshd_config
 
 EXPOSE 80
 WORKDIR $MZBENCH_API_DIR


### PR DESCRIPTION
MZBench workers cannot be ssh'd into due to missing password on root user. 

```Stage provisioning failed: {cmd_failed, "ssh -A -o LogLevel=ERROR -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@100.65.195.111 \"source /etc/profile; mkdir -p /tmp/mz/bench-0-1562785108\"", 255, "Permission denied, please try again.\r\nPermission denied, please try again.\r\nroot@100.65.195.111: Permission denied (publickey,password,keyboard-interactive).\r\n"}```