### PR TITLE
Get running on OTP21/22

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Given that you can install mzbench in k8s with the command
 
 To use MZBench, you'll need:
 
- - Erlang R17+
+ - Erlang R21+
  - C++ compiler
  - Python 2.6 or 2.7 with pip
 

--- a/common_apps/mzbench_language/src/mzbl_interpreter.erl
+++ b/common_apps/mzbench_language/src/mzbl_interpreter.erl
@@ -10,8 +10,8 @@ eval_std(Expr, Env) ->
         {Res, _} = eval(Expr, undefined, Env, undefined),
         Res
     catch
-        error:{mzbl_interpreter_runtime_error, {{E, R}, _}} ->
-            erlang:raise(E, R, erlang:get_stacktrace())
+        error:{mzbl_interpreter_runtime_error, {{E, R}, _}}:ST ->
+            erlang:raise(E, R, ST)
     end.
 
 -spec eval(script_expr(), worker_state(), worker_env(), module())
@@ -21,10 +21,10 @@ eval(Expr, State, Env, WorkerProvider) ->
     try
         eval_(Expr, State, Env, WorkerProvider)
     catch
-        error:{mzbl_interpreter_runtime_error, _} = E ->
-            erlang:raise(error, E, erlang:get_stacktrace());
-        E:R ->
-            erlang:raise(error, {mzbl_interpreter_runtime_error, {{E, R}, State}}, erlang:get_stacktrace())
+        error:{mzbl_interpreter_runtime_error, _}=E:ST ->
+            erlang:raise(error, E, ST);
+        E:R:ST ->
+            erlang:raise(error, {mzbl_interpreter_runtime_error, {{E, R}, State}}, ST)
     end.
 
 -spec eval_(script_expr(), worker_state(), worker_env(), module())

--- a/common_apps/mzbench_language/src/mzbl_script.erl
+++ b/common_apps/mzbench_language/src/mzbl_script.erl
@@ -55,12 +55,10 @@ read_from_string(String) ->
     try
         mzbl_literals:convert(parse(String))
     catch
-        C:{parse_error, {_, _, ErrorInfo}} = E ->
-            ST = erlang:get_stacktrace(),
+        C:{parse_error, {_, _, ErrorInfo}} = E:ST ->
             lager:error("Parsing script file failed: ~s", [erl_parse:format_error(ErrorInfo)]),
             erlang:raise(C,E,ST);
-        C:E ->
-            ST = erlang:get_stacktrace(),
+        C:E:ST ->
             lager:error(
                 "Failed to read script '~p' 'cause of ~p~nStacktrace: ~s",
                 [String, E, pretty_errors:stacktrace(ST)]),
@@ -72,8 +70,7 @@ read(Path) ->
     try
         read_from_string(read_file(Path))
     catch
-        C:E ->
-            ST = erlang:get_stacktrace(),
+        C:E:ST ->
             lager:error(
                 "Failed to read script: ~p 'cause of ~p~nStacktrace: ~s",
                 [Path, E, pretty_errors:stacktrace(ST)]),

--- a/common_apps/mzbench_utils/src/mzb_lists.erl
+++ b/common_apps/mzbench_utils/src/mzb_lists.erl
@@ -34,7 +34,7 @@ pmap(Fun, List) ->
             Res = try
                 {Ref, {ok, Fun(Element)}}
             catch
-                C:E -> {Ref, {exception, {C,E,erlang:get_stacktrace()}}}
+                C:E:ST -> {Ref, {exception, {C,E,ST}}}
             end,
             Self ! Res
         end),

--- a/common_apps/mzbench_utils/src/mzb_subprocess.erl
+++ b/common_apps/mzbench_utils/src/mzb_subprocess.erl
@@ -47,12 +47,10 @@ remote_cmd(UserName, Hosts, Executable, Args, Logger, Opts) ->
                 exec_format(CmdStr, [], Opts, fun (_, _, _) -> ok end)
             end, Hosts)
     catch
-        C:{cmd_failed, Cmd, Code, Output} = E ->
-            ST = erlang:get_stacktrace(),
+        C:{cmd_failed, Cmd, Code, Output} = E:ST ->
             Logger(error, "[ REMOTE EXEC ] Command execution failed:~nCmd: ~s~nExit code: ~p~nOutput: ~s", [Cmd, Code, Output]),
             erlang:raise(C, E, ST);
-        C:E ->
-            ST = erlang:get_stacktrace(),
+        C:E:ST ->
             Logger(error, "[ REMOTE EXEC ] Command execution unnormally failed: ~p~nCmd: ~p~nArgs: ~p~nHosts: ~p", [E, Executable, Args, Hosts]),
             erlang:raise(C, E, ST)
     end.

--- a/node/apps/mzbench/src/mzb_bench_sup.erl
+++ b/node/apps/mzbench/src/mzb_bench_sup.erl
@@ -24,8 +24,7 @@ run_bench(ScriptPath, DefaultEnv) ->
             {error, Error} -> erlang:error({error, [mzb_string:format("Unable to start director supervisor: ~p", [Error])]})
         end
     catch _C:{error, Errors} = E when is_list(Errors) -> E;
-          C:E ->
-              ST = erlang:get_stacktrace(),
+          C:E:ST ->
               system_log:error("Failed to run benchmark ~p:~p~n~p", [C, E, ST]),
               {error, [mzb_string:format("Failed to run benchmark", [])]}
     end.
@@ -43,8 +42,8 @@ is_ready() ->
         Apps = application:which_applications(),
         false =/= lists:keyfind(mzbench, 1, Apps)
     catch
-        _:Error ->
-            system_log:error("is_ready exception: ~p~nStacktrace: ~p", [Error, erlang:get_stacktrace()]),
+        _:Error:ST ->
+            system_log:error("is_ready exception: ~p~nStacktrace: ~p", [Error, ST]),
             false
     end.
 
@@ -52,8 +51,7 @@ get_results() ->
     try
         mzb_director:attach()
     catch
-        _:E ->
-            ST = erlang:get_stacktrace(),
+        _:E:ST ->
             Str = mzb_string:format("Unexpected error: ~p~n~p", [E, ST]),
             {error, {unexpected_error, E, ST}, Str, {[], []}}
     end.

--- a/node/apps/mzbench/src/mzb_management_tcp_protocol.erl
+++ b/node/apps/mzbench/src/mzb_management_tcp_protocol.erl
@@ -34,8 +34,7 @@ dispatch({request, Ref, Msg}, State) ->
         {reply, Reply} -> ReplyFun(Reply);
         noreply -> ok
     catch
-        C:Error ->
-            ST = erlang:get_stacktrace(),
+        C:Error:ST ->
             system_log:error("Api server message handling exception: ~p~n~p", [Error, ST]),
             send_message({response, Ref, {exception, {C, Error, ST}}}, State)
     end,
@@ -76,8 +75,8 @@ handle_message({connect_nodes, HostsAndPorts}, ReplyFun) ->
         end (_Retries = 10),
         noreply
     catch
-        _:E ->
-            system_log:error("Connecting nodes error: ~p~n~p", [E, erlang:get_stacktrace()]),
+        _:E:ST ->
+            system_log:error("Connecting nodes error: ~p~n~p", [E, ST]),
             {reply, {error, E}}
     end;
 

--- a/node/apps/mzbench/src/mzb_metrics.erl
+++ b/node/apps/mzbench/src/mzb_metrics.erl
@@ -267,7 +267,7 @@ evaluate_derived_metrics(#s{metric_groups = MetricGroups} = State) ->
             undefined -> ok; % nothing was calculated
             Val -> global_set(Name, gauge, Val)
         catch
-            _:Reason -> system_log:error("Failed to evaluate derived metrics:~nWorker: ~p~nFunction: ~p~nReason: ~p~nStacktrace: ~p~n", [Worker, Resolver, Reason, erlang:get_stacktrace()])
+            _:Reason:ST -> system_log:error("Failed to evaluate derived metrics:~nWorker: ~p~nFunction: ~p~nReason: ~p~nStacktrace: ~p~n", [Worker, Resolver, Reason, ST])
         end
     end, DerivedMetrics),
     system_log:debug("[ metrics ] Current metrics values:~n~s", [format_global_metrics()]),

--- a/node/apps/mzbench/src/mzb_script_metrics.erl
+++ b/node/apps/mzbench/src/mzb_script_metrics.erl
@@ -32,8 +32,7 @@ script_metrics(Pools, _WorkerNodes) ->
         PoolMetrics = pool_metrics(Pools),
         normalize(PoolMetrics ++ MZBenchInternal)
     catch
-        _:Error ->
-            ST = erlang:get_stacktrace(),
+        _:Error:ST ->
             system_log:error("Metrics declaration error: ~s", [mzb_script_metrics:format_error(Error)]),
             erlang:raise(error, Error, ST)
     end.

--- a/node/apps/mzbench/src/mzb_script_validator.erl
+++ b/node/apps/mzbench/src/mzb_script_validator.erl
@@ -15,30 +15,29 @@ read_and_validate(ScriptFileName, Env) ->
         {ok, Warnings} = validate(Body),
         {ok, Warnings, Body, AutoEnv ++ Env}
     catch
-        C:{read_file_error, File, E} = Error ->
+        C:{read_file_error, File, E} = Error:ST ->
             Message = mzb_string:format(
                 "Failed to read file ~s: ~s",
                 [File, file:format_error(E)]),
-            {error, C, Error, erlang:get_stacktrace(), [Message]};
-        C:{parse_error, {LineNumber, erl_parse, E}} = Error ->
+            {error, C, Error, ST, [Message]};
+        C:{parse_error, {LineNumber, erl_parse, E}} = Error:ST ->
             Message = mzb_string:format(
                 "Failed to parse script ~s:~nline ~p: ~s",
                 [ScriptFileName, LineNumber, [E]]),
-            {error, C, Error, erlang:get_stacktrace(), [Message]};
-        C:{parse_error,{expected, E, {{line, LineNumber}, {column, ColumnNumber}}}} = Error ->
+            {error, C, Error, ST, [Message]};
+        C:{parse_error,{expected, E, {{line, LineNumber}, {column, ColumnNumber}}}} = Error:ST ->
             Message = mzb_string:format(
                 "Failed to parse script ~s:~nline ~p, column ~p: ~p",
                 [ScriptFileName, LineNumber, ColumnNumber, E]),
-            {error, C, Error, erlang:get_stacktrace(), [Message]};
-        C:{invalid_operation_name, Name} = Error ->
-            {error, C, Error, erlang:get_stacktrace(),
+            {error, C, Error, ST, [Message]};
+        C:{invalid_operation_name, Name} = Error:ST ->
+            {error, C, Error, ST,
                 [mzb_string:format("Script ~s is invalid:~nInvalid operation name ~p~n",
                     [ScriptFileName, Name])]};
-        C:{error, {validation, VM}} = Error when is_list(VM) ->
+        C:{error, {validation, VM}} = Error:ST when is_list(VM) ->
             Messages = [mzb_string:format("Script ~s is invalid:~n", [ScriptFileName]) | VM],
-            {error, C, Error, erlang:get_stacktrace(), Messages};
-        C:Error ->
-            ST = erlang:get_stacktrace(),
+            {error, C, Error, ST, Messages};
+        C:Error:ST ->
             Message = mzb_string:format(
                 "Script ~s is invalid:~nError: ~p~n~nStacktrace for the curious: ~p",
                 [ScriptFileName, Error, ST]),

--- a/node/apps/mzbench/src/mzb_system_load_monitor.erl
+++ b/node/apps/mzbench/src/mzb_system_load_monitor.erl
@@ -167,7 +167,7 @@ handle_info(trigger,
 
         State#state{net_stat_state = NetStat}
     catch
-        C:E -> system_log:error("Exception while getting net stats: ~p~nStacktrace: ~p", [{C,E}, erlang:get_stacktrace()]),
+        C:E:ST -> system_log:error("Exception while getting net stats: ~p~nStacktrace: ~p", [{C,E}, ST]),
         State
     end,
 

--- a/node/apps/mzbench/src/mzb_worker_runner.erl
+++ b/node/apps/mzbench/src/mzb_worker_runner.erl
@@ -34,11 +34,9 @@ catch_eval(Script, State, Env, {Provider, _}) ->
         {Result, ResState} = mzbl_interpreter:eval(Script, State, Env, Provider),
         {{ok, Result}, ResState}
     catch
-        error:{mzbl_interpreter_runtime_error, {{Error, Reason}, ErrorState}} ->
-            ST = erlang:get_stacktrace(),
+        error:{mzbl_interpreter_runtime_error, {{Error, Reason}, ErrorState}}:ST ->
             {{exception, {Error, Reason, ST}}, ErrorState};
-        C:E ->
-            ST = erlang:get_stacktrace(),
+        C:E:ST ->
             {{exception, {C, E, ST}}, unknown}
     end.
 
@@ -46,7 +44,7 @@ catch_init({Provider, Worker}) ->
     try Provider:init(Worker) of
         InitialState -> {ok, InitialState}
     catch
-        C:E -> {exception, {C, E, erlang:get_stacktrace()}}
+        C:E:ST -> {exception, {C, E, ST}}
     end.
 
 catch_terminate({ok, Res}, {WorkerProvider, _}, WorkerState) ->
@@ -54,8 +52,8 @@ catch_terminate({ok, Res}, {WorkerProvider, _}, WorkerState) ->
         WorkerProvider:terminate(Res, WorkerState),
         {ok, Res}
     catch
-        Class:Error ->
-            {exception, node(), {Class, Error, erlang:get_stacktrace()}, WorkerState}
+        Class:Error:ST ->
+            {exception, node(), {Class, Error, ST}, WorkerState}
     end;
 catch_terminate({exception, Spec}, _, unknown) ->
     %% do not call terminate in this case because worker provider
@@ -66,8 +64,7 @@ catch_terminate({exception, Spec}, {WorkerProvider, _}, WorkerState) ->
         WorkerProvider:terminate(Spec, WorkerState),
         {exception, node(), Spec, WorkerState}
     catch
-        Class:Error ->
-            ST = erlang:get_stacktrace(),
+        Class:Error:ST ->
             {exception, node(), {Class, Error, ST}, unknown}
     end.
 

--- a/node/scripts/wait_cluster_start.escript
+++ b/node/scripts/wait_cluster_start.escript
@@ -121,8 +121,8 @@ is_node_ready(Node) ->
             false -> false
         end
     catch
-        _:E ->
-            io:format("is_node_ready exception: ~p~n~p", [E, erlang:get_stacktrace()]),
+        _:E:ST ->
+            io:format("is_node_ready exception: ~p~n~p", [E, ST]),
             false
     end,
 

--- a/server/rebar.config
+++ b/server/rebar.config
@@ -30,6 +30,11 @@
             {git, "git://github.com/machinezone/hdr_histogram_erl.git", {tag, 'experimental-multithread-support2'}}}
         ]}.
 
+{overrides, [
+             %% overrides to get it compiling on OTP 22
+             {override, meck, [{erl_opts, [debug_info]}]}
+            ]}.
+
 {deps_dir, "deps"}.
 
 {lib_dirs, ["deps"]}.

--- a/server/src/mzb_api_cloud.erl
+++ b/server/src/mzb_api_cloud.erl
@@ -37,9 +37,9 @@ destroy_cluster(Id) ->
                 gen_server:call(?MODULE, {deallocated, Id}, infinity),
                 ok
             catch
-                C:E ->
+                C:E:ST ->
                     gen_server:call(?MODULE, {deallocation_failed, Id, E}, infinity),
-                    erlang:raise(C, E, erlang:get_stacktrace())
+                    erlang:raise(C, E, ST)
             end;
         {error, Error} ->
             erlang:error(Error)
@@ -88,9 +88,9 @@ handle_call({get_allocator, BenchId, Cloud, N, Config}, _From, State = #{cluster
                         gen_server:call(Self, {allocated, Id, Cluster, User, Hosts}, infinity),
                         {ok, Id, User, Hosts}
                     catch
-                        C:E ->
+                        C:E:ST ->
                             gen_server:call(Self, {allocation_failed, Id, E}, infinity),
-                            erlang:raise(C, E, erlang:get_stacktrace())
+                            erlang:raise(C, E, ST)
                     end
                 end,
             {reply, {ok, F}, State#{cluster_id:= Id + 1}};

--- a/server/src/mzb_api_connection.erl
+++ b/server/src/mzb_api_connection.erl
@@ -18,8 +18,7 @@ start_and_link_with(PidToLinkWith, Purpose, Host, Port, Dispatcher, State) ->
             {error, Reason} ->
                 Self ! {self(), failed, Reason}
         catch
-            C:E ->
-                ST = erlang:get_stacktrace(),
+            C:E:ST ->
                 Self ! {self(), failed, {C, E, ST}}
         end
     end),

--- a/server/src/mzb_api_ec2_plugin.erl
+++ b/server/src/mzb_api_ec2_plugin.erl
@@ -32,8 +32,7 @@ create_cluster(Opts = #{instance_user:= UserName}, NumNodes, Config) when is_int
         wait_nodes_ssh(IPs, ?MAX_POLL_COUNT),
         {ok, {Opts, Ids}, UserName, IPs}
     catch
-        C:E ->
-            ST = erlang:get_stacktrace(),
+        C:E:ST ->
             destroy_cluster({Opts, Ids}),
             erlang:raise(C,E,ST)
     end.

--- a/server/src/mzb_api_endpoints.erl
+++ b/server/src/mzb_api_endpoints.erl
@@ -40,8 +40,8 @@ init(Req, _Opts) ->
             Req2 = reply_error(403, <<"forbidden">>, Description, Req),
             {ok, Req2, #{}};
 
-        _:E ->
-            Description = io_lib:format("Server Internal Error: ~p~n~nReq: ~p~n~nStacktrace: ~p", [E, Req, erlang:get_stacktrace()]),
+        _:E:ST ->
+            Description = io_lib:format("Server Internal Error: ~p~n~nReq: ~p~n~nStacktrace: ~p", [E, Req, ST]),
             Req2 = reply_error(500, <<"internal_error">>, Description, Req),
             lager:error(Description),
             {ok, Req2, #{}}

--- a/server/src/mzb_api_metrics.erl
+++ b/server/src/mzb_api_metrics.erl
@@ -13,8 +13,7 @@ get_metrics(UserName, DirNode, Host, RemoteScriptPath, RemoteEnvPath) ->
     try
         jiffy:decode(Res, [return_maps])
     catch
-        C:E ->
-            ST = erlang:get_stacktrace(),
+        C:E:ST ->
             lager:error("Failed to parse metrics names cause of ~p~nOutput: ~p~nStacktrace: ~p", [E, Res, ST]),
             erlang:raise(C,E,ST)
     end.

--- a/server/src/mzb_api_server.erl
+++ b/server/src/mzb_api_server.erl
@@ -538,8 +538,8 @@ save_results(Id, Status, State) ->
         write_status(Id, Status, State),
         true = ets:update_element(benchmarks, Id, {3, Status})
     catch
-        _:Error ->
-            lager:error("Save bench #~b results failed with reason: ~p~n~p", [Id, Error, erlang:get_stacktrace()])
+        _:Error:ST ->
+            lager:error("Save bench #~b results failed with reason: ~p~n~p", [Id, Error, ST])
     end.
 
 write_status(Id, Status, #{data_dir:= Dir}) ->
@@ -562,8 +562,8 @@ import_data(Dir) ->
             import_bench_status(Id, File),
             max(Id, Max)
         catch
-            _:Error ->
-                lager:error("Parsing status filename ~s failed with reason: ~p~n~p", [File, Error, erlang:get_stacktrace()]),
+            _:Error:ST ->
+                lager:error("Parsing status filename ~s failed with reason: ~p~n~p", [File, Error, ST]),
                 Max
         end
     end,
@@ -574,8 +574,8 @@ import_bench_status(Id, File) ->
         {ok, [Status]} = file:consult(File),
         #{status:= _, start_time := _, finish_time := _, config := #{}} = Status,
         ets:insert(benchmarks, {Id, undefined, Status})
-    catch _:E ->
-        lager:error("Import from file ~s failed with reason: ~p~n~p", [File, E, erlang:get_stacktrace()])
+    catch _:E:ST ->
+        lager:error("Import from file ~s failed with reason: ~p~n~p", [File, E, ST])
     end.
 
 sys_username() ->

--- a/server/src/mzb_api_ws_handler.erl
+++ b/server/src/mzb_api_ws_handler.erl
@@ -754,8 +754,8 @@ filter_dashboards(List, Query) ->
           {match, _} -> true;
                    _ -> false
         end end, List)
-    catch _:Error ->
-        lager:error("Failed to apply dashboard filter: ~p ~p~n Query: ~p -- List ~p", [Error, erlang:get_stacktrace(), Query, List]),
+    catch _:Error:ST ->
+        lager:error("Failed to apply dashboard filter: ~p ~p~n Query: ~p -- List ~p", [Error, ST, Query, List]),
         []
     end.
 
@@ -807,8 +807,8 @@ is_satisfy_fields(Query, BenchInfo) ->
                       ({exact, Field}) ->
                           Field == Query
                   end, SearchFields)
-    catch _:Error ->
-        lager:error("Failed to apply filter: ~p ~p~n Query: ~p -- BenchInfo ~p", [Error, erlang:get_stacktrace(), Query, BenchInfo]),
+    catch _:Error:ST ->
+        lager:error("Failed to apply filter: ~p ~p~n Query: ~p -- BenchInfo ~p", [Error, ST, Query, BenchInfo]),
         false
     end.
 

--- a/server/src/mzb_k8s_plugin.erl
+++ b/server/src/mzb_k8s_plugin.erl
@@ -60,8 +60,7 @@ create_cluster(PluginOpts, NumNodes, ClusterConfig) when is_integer(NumNodes), N
         lager:info("Pods are ssh-ready ~p", [PodNames]),
         {ok, ID, UserName, IPs}
     catch
-        C:E ->
-            ST = erlang:get_stacktrace(),
+        C:E:ST ->
             destroy_cluster(ID),
             erlang:raise(C,E,ST)
     end.

--- a/server/src/mzb_pipeline.erl
+++ b/server/src/mzb_pipeline.erl
@@ -172,11 +172,9 @@ handle_cast({workflow, start, Phase, Stage, Ref}, State = #state{ref = Ref, modu
                 StageResult = Module:handle_stage(Phase, Stage, UserState),
                 gen_server:cast(Self, {workflow, complete, Phase, Stage, Ref, StageResult})
             catch
-                C:{exception, E, Fn} ->
-                    ST = erlang:get_stacktrace(),
+                C:{exception, E, Fn}:ST ->
                     gen_server:cast(Self, {workflow, exception, Phase, Stage, Ref, {C, E, ST, Fn}});
-                C:E ->
-                    ST = erlang:get_stacktrace(),
+                C:E:ST ->
                     gen_server:cast(Self, {workflow, exception, Phase, Stage, Ref, {C, E, ST, undefined}})
             end
         end),

--- a/workers/tcpkali/src/tcpkali_worker.erl
+++ b/workers/tcpkali/src/tcpkali_worker.erl
@@ -503,9 +503,9 @@ json2cbor(State, _Meta, Str, Type) ->
     JSON =
         try jiffy:decode(Str3, [return_maps])
         catch
-            C:E ->
+            C:E:ST ->
                 lager:error("Bad json: ~s", [Str3]),
-                erlang:raise(C, E, erlang:get_stacktrace())
+                erlang:raise(C, E, ST)
         end,
 
     CBORBin = erlang:iolist_to_binary(cbor:encode(JSON)),


### PR DESCRIPTION
This PR:

- overrides the `meck` dependency so the compilation doesn't fail due to the `erlang:get_stacktrace/0`,
- rewrites uses of `erlang:get_stacktrace/0` to use the pattern matching instead.

With this I can at least run `./bin/mzbench start_server` without getting any compile errors. I do get an error: 

``` text
Executing make -C /home/lhc/dev/octavolabs/mzbench/bin/../server generate
........................
Waiting for server application start
..............................Server has failed to start, timeout
Check /home/lhc/dev/octavolabs/mzbench/bin/../server/log/error.log for details

```

but unfortunately the error.log file is empty. Anyway I guess this is a start.

At least partially fixes #9.