### PR TITLE
Use erlang:22.1.8-alpine in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ### --- Build mzbench artifacts --- ###
-FROM erlang:20.3.8-alpine as build
+FROM erlang:22.1.8-alpine as build
 
 ENV ORIG_PATH=$PATH
 ENV CODE_LOADING_MODE=interactive


### PR DESCRIPTION
Resolves #15 

Image builds without problems AFAICS and it's running correctly in my Kubernetes cluster